### PR TITLE
Add cloudmesh-docker repo to docker bundle

### DIFF
--- a/cloudmesh_installer/install/bundle.py
+++ b/cloudmesh_installer/install/bundle.py
@@ -169,7 +169,10 @@ repos = OrderedDict({
 #        'cloudmesh-storage',
     ],
 
-    'docker': ['cloudmesh-cmsd'],
+    'docker': [
+        'cloudmesh-cmsd',
+        'cloudmesh-docker'
+    ],
 
     'iu': cms + cloud + [   # add cloud so the yaml file gets created
         'cloudmesh-iu'


### PR DESCRIPTION
Currently, the only way to install `cloudmesh-docker` using `cloudmesh-installer` is by downloading the "source" bundle, which includes over 30 additional packages:

![Screen Shot 2020-10-18 at 5 46 21 PM](https://user-images.githubusercontent.com/13988685/96386579-f97eb100-1169-11eb-8099-9c6610778f78.png)

There's also a "docker" bundle that doesn't contain `cloudmesh-docker`:

![Screen Shot 2020-10-18 at 5 51 20 PM](https://user-images.githubusercontent.com/13988685/96386657-8a558c80-116a-11eb-971f-7a5804663b4c.png)

This PR adds `cloudmesh-docker` to the "docker" bundle so that users can install `cloudmesh-docker` without installing 30+ additional packages.

